### PR TITLE
Remove duplicate select2 includes from admin template fixes #30

### DIFF
--- a/templates/admin.php
+++ b/templates/admin.php
@@ -19,8 +19,6 @@
  *
  */
 
-vendor_script('core', 'select2/select2');
-vendor_style('core', 'select2/select2');
 script('core', [
 	'oc-backbone-webdav',
 	'systemtags/systemtags',


### PR DESCRIPTION
This was overriding the core styles, with the vendor ones

fixes #30 