### PR TITLE
Use the first existing result

### DIFF
--- a/lib/BackgroundJob/RetentionJob.php
+++ b/lib/BackgroundJob/RetentionJob.php
@@ -155,20 +155,20 @@ class RetentionJob extends TimedJob {
 	private function checkFileId($fileid) {
 		$mountPoints = $this->userMountCache->getMountsForFileId($fileid);
 
-		if (count($mountPoints) === 0) {
+		if (empty($mountPoints)) {
 			throw new NotFoundException();
 		}
 
-		$mountPoint = $mountPoints[0];
+		$mountPoint = array_shift($mountPoints);
 
 		$userFolder = $this->rootFolder->getUserFolder($mountPoint->getUser()->getUID());
 
 		$nodes = $userFolder->getById($fileid);
-		if (count($nodes) === 0) {
+		if (empty($nodes)) {
 			throw new NotFoundException();
 		}
 
-		return $nodes[0];
+		return array_shift($nodes);
 	}
 
 	/**


### PR DESCRIPTION
Because getById and getMountsForFileId use array_filter
index 0 might not exist, so we just shift of the first
result instead.

Fix #38 

---

PS: we seem to have this same mistake in quite a lot of places and so far it "just worked". Maybe we should instead fix `getMountsForFileId` and `getById` to return `array_value()` which closes the index gaps.