### PR TITLE
Correctly trigger View hooks on retention

### DIFF
--- a/lib/BackgroundJob/RetentionJob.php
+++ b/lib/BackgroundJob/RetentionJob.php
@@ -23,6 +23,7 @@
 namespace OCA\Files_Retention\BackgroundJob;
 
 use OC\BackgroundJob\TimedJob;
+use OC\Files\Filesystem;
 use OCA\Files_Retention\AppInfo\Application;
 use OCA\Files_Retention\Constants;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -177,7 +178,13 @@ class RetentionJob extends TimedJob {
 		$mountPoint = array_shift($mountPoints);
 
 		try {
-			$userFolder = $this->rootFolder->getUserFolder($mountPoint->getUser()->getUID());
+			$userId = $mountPoint->getUser()->getUID();
+			$userFolder = $this->rootFolder->getUserFolder($userId);
+			if (!Filesystem::$loaded) {
+				// Filesystem wasn't loaded for anyone,
+				// so we boot it up in order to make hooks in the View work.
+				Filesystem::init($userId, '/' . $userId . '/files');
+			}
 		} catch (\Exception $e) {
 			$this->logger->logException($e, ['level' => ILogger::DEBUG]);
 			throw new NotFoundException('Could not get user');


### PR DESCRIPTION
### Steps
1. Upload a file
2. Create a tag
3. Set up retention rule for the tag
4. Enable admin_audit app
5. Reset `last_run` and `last_checked` in `oc_jobs` for the `OCA\Files_Retention\BackgroundJob\RetentionJob` row
6. Remove last digit from `upload_time` in `oc_filecache_extended`
7. Run cron job
8. See the file is gone
9. See that admin audit log doesn't say it was deleted 👀 