### PR TITLE
add time selection after which files should be deleted

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -98,6 +98,7 @@
 			}
 			$el.tooltip('hide');
 
+			var after = parseInt($('#retention_after').val(), 10);
 			var unit = parseInt($('#retention_unit').val(), 10);
 			amount = parseInt(amount, 10);
 
@@ -108,7 +109,8 @@
 			this.collection.create({
 				tagid: this.currentTagId,
 				timeunit: unit,
-				timeamount: amount
+				timeamount: amount,
+				timeafter: after,
 			});
 
 			$('#retention_submit').prop('disabled', true);

--- a/js/retentionmodel.js
+++ b/js/retentionmodel.js
@@ -35,7 +35,12 @@
 			1: 'weeks',
 			2: 'months',
 			3: 'years'
-		}
+		},
+
+		RETENTION_AFTER_MAP: {
+			0: 'creation',
+			1: 'last modification',
+		},
 	});
 
 	var RetentionModel = OC.Backbone.Model.extend({

--- a/js/retentionview.js
+++ b/js/retentionview.js
@@ -61,6 +61,7 @@
 					tagName: _this.tagCollection.get(model.attributes.tagid).attributes.name,
 					timeAmount: model.attributes.timeamount,
 					timeUnit: t('files_retention', OCA.File_Retention.RETENTION_UNIT_MAP[model.attributes.timeunit]),
+					timeAfter: OCA.File_Retention.RETENTION_AFTER_MAP[model.attributes.timeafter],
 					hasJob: model.attributes.hasJob ? t('files_retention', 'Yes') : t('files_retention', 'No'),
 				};
 				var html = _this.template(data);

--- a/js/template.handlebars
+++ b/js/template.handlebars
@@ -2,6 +2,7 @@
 	<td><span>{{tagName}}</span></td>
 	<td><span>{{timeAmount}}</span></td>
 	<td><span>{{timeUnit}}</span></td>
+	<td><span>{{timeAfter}}</span></td>
 	<td><span>{{hasJob}}</span></td>
 	<td><a class="icon-delete has-tooltip" title="{{deleteString}}"></a></td>
 <tr>

--- a/js/template.js
+++ b/js/template.js
@@ -17,9 +17,11 @@ templates['template'] = template({"compiler":[8,">= 4.3.0"],"main":function(cont
     + "</span></td>\n	<td><span>"
     + alias4(((helper = (helper = lookupProperty(helpers,"timeUnit") || (depth0 != null ? lookupProperty(depth0,"timeUnit") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"timeUnit","hash":{},"data":data,"loc":{"start":{"line":4,"column":11},"end":{"line":4,"column":23}}}) : helper)))
     + "</span></td>\n	<td><span>"
-    + alias4(((helper = (helper = lookupProperty(helpers,"hasJob") || (depth0 != null ? lookupProperty(depth0,"hasJob") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"hasJob","hash":{},"data":data,"loc":{"start":{"line":5,"column":11},"end":{"line":5,"column":21}}}) : helper)))
+    + alias4(((helper = (helper = lookupProperty(helpers,"timeAfter") || (depth0 != null ? lookupProperty(depth0,"timeAfter") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"timeAfter","hash":{},"data":data,"loc":{"start":{"line":5,"column":11},"end":{"line":5,"column":24}}}) : helper)))
+    + "</span></td>\n	<td><span>"
+    + alias4(((helper = (helper = lookupProperty(helpers,"hasJob") || (depth0 != null ? lookupProperty(depth0,"hasJob") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"hasJob","hash":{},"data":data,"loc":{"start":{"line":6,"column":11},"end":{"line":6,"column":21}}}) : helper)))
     + "</span></td>\n	<td><a class=\"icon-delete has-tooltip\" title=\""
-    + alias4(((helper = (helper = lookupProperty(helpers,"deleteString") || (depth0 != null ? lookupProperty(depth0,"deleteString") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"deleteString","hash":{},"data":data,"loc":{"start":{"line":6,"column":47},"end":{"line":6,"column":63}}}) : helper)))
+    + alias4(((helper = (helper = lookupProperty(helpers,"deleteString") || (depth0 != null ? lookupProperty(depth0,"deleteString") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"deleteString","hash":{},"data":data,"loc":{"start":{"line":7,"column":47},"end":{"line":7,"column":63}}}) : helper)))
     + "\"></a></td>\n<tr>\n";
 },"useData":true});
 })();

--- a/lib/BackgroundJob/RetentionJob.php
+++ b/lib/BackgroundJob/RetentionJob.php
@@ -136,6 +136,8 @@ class RetentionJob extends TimedJob {
 		$deleteBefore = $this->getBeforeDate((int)$data['time_unit'], (int)$data['time_amount']);
 		$notifyBefore = $this->getNotifyBeforeDate($deleteBefore);
 
+		$timeAfter = (int)$data['time_after'];
+
 		$offset = '';
 		$limit = 1000;
 		while ($offset !== null) {
@@ -149,7 +151,7 @@ class RetentionJob extends TimedJob {
 					continue;
 				}
 
-				$deleted = $this->expireNode($node, $deleteBefore);
+				$deleted = $this->expireNode($node, $deleteBefore, $timeAfter);
 
 				if ($notifyDayBefore && !$deleted) {
 					$this->notifyNode($node, $notifyBefore);
@@ -205,14 +207,14 @@ class RetentionJob extends TimedJob {
 	 * @param Node $node
 	 * @param \DateTime $deleteBefore
 	 */
-	private function expireNode(Node $node, \DateTime $deleteBefore) {
+	private function expireNode(Node $node, \DateTime $deleteBefore, int $timeAfter) {
 		$mtime = new \DateTime();
 
 		// Fallback is the mtime
 		$mtime->setTimestamp($node->getMTime());
 
 		// Use the upload time if we have it
-		if ($node->getUploadTime() !== 0) {
+		if ($timeAfter === Constants::CTIME && $node->getUploadTime() !== 0) {
 			$mtime->setTimestamp($node->getUploadTime());
 		}
 

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -27,4 +27,7 @@ class Constants {
 	const WEEK = 1;
 	const MONTH = 2;
 	const YEAR = 3;
+
+	const CTIME = 0;
+	const MTIME = 1;
 }

--- a/lib/Migration/Version011000Date20210206170027.php
+++ b/lib/Migration/Version011000Date20210206170027.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Files_Retention\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version011000Date20210206170027 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('retention')) {
+			$table = $schema->getTable('retention');
+
+			$table->addColumn('time_after', 'integer', [
+				'length' => 4,
+				'default' => 0,
+			]);
+		}
+
+		return $schema;
+	}
+
+}

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -55,6 +55,7 @@ style('files_retention', [
 			<th>Tag</th>
 			<th>Retention</th>
 			<th>Time</th>
+			<th>After</th>
 			<th>Active</th>
 			<th></th>
 		</thead>
@@ -72,6 +73,13 @@ style('files_retention', [
 		<option value="1"><?php p($l->t('Weeks')); ?></option>
 		<option value="2"><?php p($l->t('Months')); ?></option>
 		<option value="3"><?php p($l->t('Years')); ?></option>
+	</select>
+
+	<?php p($l->t('after')); ?>
+
+	<select id="retention_after">
+		<option value="0"><?php p($l->t('Creation')); ?></option>
+		<option value="1"><?php p($l->t('Last modification')); ?></option>
 	</select>
 
 	<input type="button" id="retention_submit" value="<?php p($l->t('Create')); ?>" disabled>

--- a/tests/lib/Contoller/APIControllerTest.php
+++ b/tests/lib/Contoller/APIControllerTest.php
@@ -127,6 +127,7 @@ class APIControllerTest extends \Test\TestCase {
 			'tagid' => 42,
 			'timeunit' => Constants::MONTH,
 			'timeamount' => 1,
+			'timeafter' => 0,
 		];
 		$this->assertSame($expected, $response->getData());
 	}
@@ -163,15 +164,15 @@ class APIControllerTest extends \Test\TestCase {
 			],
 			[
 				[
-					[1, Constants::DAY, 1],
+					[1, Constants::DAY, 1, 0],
 				]
 			],
 			[
 				[
-					[1, Constants::DAY, 1],
-					[2, Constants::WEEK, 2],
-					[3, Constants::MONTH, 3],
-					[4, Constants::YEAR, 4],
+					[1, Constants::DAY, 1, 0],
+					[2, Constants::WEEK, 2, 0],
+					[3, Constants::MONTH, 3, 1],
+					[4, Constants::YEAR, 4, 1],
 				]
 			],
 		];
@@ -190,7 +191,8 @@ class APIControllerTest extends \Test\TestCase {
 			$qb->insert('retention')
 				->setValue('tag_id', $qb->createNamedParameter($d[0]))
 				->setValue('time_unit', $qb->createNamedParameter($d[1]))
-				->setValue('time_amount', $qb->createNamedParameter($d[2]));
+				->setValue('time_amount', $qb->createNamedParameter($d[2]))
+				->setValue('time_after', $qb->createNamedParameter($d[3]));
 			$qb->execute();
 
 			$id = $qb->getLastInsertId();
@@ -200,6 +202,7 @@ class APIControllerTest extends \Test\TestCase {
 				'tagid' => $d[0],
 				'timeunit' => $d[1],
 				'timeamount' => $d[2],
+				'timeafter' => $d[3],
 			];
 		}
 
@@ -266,6 +269,7 @@ class APIControllerTest extends \Test\TestCase {
 			'tagid' => 42,
 			'timeunit' => $timeunit === null ? Constants::DAY : $timeunit,
 			'timeamount' => $timeamount === null ? 1 : $timeamount,
+			'timeafter' => 0,
 		];
 
 		$response = $this->api->editRetention($id, $timeunit, $timeamount);


### PR DESCRIPTION
This change should be backward compatible.

This comes handy if you want to delete files e.g. X days after the last modification. It's probably still confusing for the user, because upload time (creation time) is only available if the file was uploaded via webdav, but I don't have enough information about the file handling to fix this issue.

We need this enhancement for the outlook addon from Sendent.

Todo:
- [x] adapt tests

cc @usselite