### PR TITLE
remove filesystem type

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,10 +10,6 @@
 	<author>Roeland Jago Douma</author>
 	<namespace>Files_Retention</namespace>
 
-	<types>
-		<filesystem/>
-	</types>
-
 	<documentation>
 		<admin>https://docs.nextcloud.com/server/22/go.php?to=admin-files-retention</admin>
 	</documentation>


### PR DESCRIPTION
this should not be needed and it prevents that the trash bin
app is guaranteed to be loaded before

fix #34