### PR TITLE
Fixing error on adding new retention rule

### DIFF
--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -79,7 +79,7 @@ class APIController extends Controller {
 		return new JSONResponse($result);
 	}
 
-	public function addRetention(string $tagid, int $timeunit, int $timeamount, int $timeafter = Constants::CTIME): Response {
+	public function addRetention(int $tagid, int $timeunit, int $timeamount, int $timeafter = Constants::CTIME): Response {
 		$response = new Response();
 
 		try {


### PR DESCRIPTION
Fixing exception OCA\Files_Retention\Controller\APIController::addRetention(): Argument #1 ($tagid) must be of type string, int given, called in /var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php on line 225 in file '/var/www/nextcloud/apps/files_retention/lib/Controller/APIController.php' line 82
Looks like a typo during "php 7.4 cleanup" [6c9e898](https://github.com/nextcloud/files_retention/pull/162/commits/6c9e898c484d619d44fa3e172a2a9f6bac982d0d)