### PR TITLE
Updating dependabot-approve-merge.yml workflow from template

### DIFF
--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency: 
+  group: dependabot-approve-merge-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   auto-approve-merge:
     if: github.actor == 'dependabot[bot]'


### PR DESCRIPTION
Automated update of the dependabot-approve-merge.yml workflow from https://github.com/nextcloud/.github