### PR TITLE
[stable26] Update nextcloud/ocp dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,6 @@
 		"phpunit/phpunit": "^9.5",
 		"nextcloud/coding-standard": "^1.0.0",
 		"vimeo/psalm": "^5.1.0",
-		"nextcloud/ocp": "dev-master"
+		"nextcloud/ocp": "dev-stable26"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7137e3a8575aa081caa22aebec2f632b",
+    "content-hash": "47931aa841a334bcd1b8d82a3404387a",
     "packages": [],
     "packages-dev": [
         {
@@ -1123,16 +1123,16 @@
         },
         {
             "name": "nextcloud/ocp",
-            "version": "dev-master",
+            "version": "dev-stable26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "c4a05e2e3b749899fb3dd5577ecb5763d3993da3"
+                "reference": "d1142002189596564d2575b35cbf13f17ff1b4a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/c4a05e2e3b749899fb3dd5577ecb5763d3993da3",
-                "reference": "c4a05e2e3b749899fb3dd5577ecb5763d3993da3",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d1142002189596564d2575b35cbf13f17ff1b4a2",
+                "reference": "d1142002189596564d2575b35cbf13f17ff1b4a2",
                 "shasum": ""
             },
             "require": {
@@ -1142,7 +1142,6 @@
                 "psr/event-dispatcher": "^1.0",
                 "psr/log": "^1.1"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -1162,9 +1161,9 @@
             "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/master"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/stable26"
             },
-            "time": "2023-02-22T00:36:09+00:00"
+            "time": "2023-03-03T14:19:31+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency