### PR TITLE
Version 1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 1.17.1 - 2024-02-26
+
+### Fixed
+
+- Fix `retention time` and `from date of` fields. (@nickvergessen)
+  [#479](https://github.com/nextcloud/files_retention/pull/479)
+
+### Changed
+
+- 🔌 Upgrade Nextcloud server API definition.
+
 ## 1.17.0 - 2024-01-22
 ### Changed
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<summary>This application allows for automatic deletion of files after a given time.</summary>
 	<description>An app for Nextcloud to control automatic deletion of files after a given time.
 Optionally the users can be informed the day before.</description>
-	<version>1.17.0</version>
+	<version>1.17.1</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<namespace>Files_Retention</namespace>


### PR DESCRIPTION
**Fixed**

- Fix `retention time` and `from date of` fields. (@nickvergessen) [#479](https://github.com/nextcloud/files_retention/pull/479)

**Changed**

- 🔌 Upgrade Nextcloud server API definition.