### PR TITLE
chore(deps-dev): bump @nextcloud/webpack-vue-config from 6.3.2 to 7.0.2 and specify actually used vue-loader 15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@nextcloud/eslint-config": "^8.4.2",
         "@nextcloud/stylelint-config": "^3.1.1",
         "@nextcloud/typings": "^1.10.0",
-        "@nextcloud/webpack-vue-config": "^6.3.2",
+        "@nextcloud/webpack-vue-config": "^7.0.2",
         "ts-loader": "^9.5.4",
         "typescript": "^5.9.3",
         "vue-loader": "^15.11.1"
@@ -2650,14 +2650,14 @@
       }
     },
     "node_modules/@nextcloud/webpack-vue-config": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/webpack-vue-config/-/webpack-vue-config-6.3.2.tgz",
-      "integrity": "sha512-3ihWEW6kflGggVXNqL1gNrIx88GibJMIb1sC5CHjjZ/+2kkdOQ2HizoYKyMqPfcqji9UtwgdT+RlFVC4SViNJg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/webpack-vue-config/-/webpack-vue-config-7.0.2.tgz",
+      "integrity": "sha512-7pzQptkQ4XEi9hyhLjdJLAyG4ZnnHuDNsOnMBc1RcRniMCTBp8xD5T1H3gCm4lKmB5/pEyuTK52/rj1w/xqmKw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "AGPL-3.0-or-later",
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^9.0.0 || ^10.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.22.9",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nextcloud/eslint-config": "^8.4.2",
     "@nextcloud/stylelint-config": "^3.1.1",
     "@nextcloud/typings": "^1.10.0",
-    "@nextcloud/webpack-vue-config": "^6.3.2",
+    "@nextcloud/webpack-vue-config": "^7.0.2",
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "vue-loader": "^15.11.1"


### PR DESCRIPTION
- Ref: https://github.com/nextcloud/files_retention/pull/856
- `vue-loader@17` is not compatible with Vue 2
- It works because for demi-vue support `@nextcloud/webpack-vue-config` afterwards installs the correct version ignoring the package file
- Bump `@nextcloud/webpack-vue-config` to v7 which doesn't allow this anymore having everything according to the lock file