### PR TITLE
[stable34] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "72de02fbad95545055983d050e564fe39128992d"
+                "reference": "6f7475c163404df11cde86535e3ad0b46abca5a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/72de02fbad95545055983d050e564fe39128992d",
-                "reference": "72de02fbad95545055983d050e564fe39128992d",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6f7475c163404df11cde86535e3ad0b46abca5a1",
+                "reference": "6f7475c163404df11cde86535e3ad0b46abca5a1",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable34"
             },
-            "time": "2026-05-15T08:43:27+00:00"
+            "time": "2026-05-20T02:08:51+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency