### PR TITLE
[stable34] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
 9cbb4d651a9ac018f04b663ddd2c87bb appstore-build-publish.yml
-56cf6e8b165be4343be41f47c1e79a9c dependabot-approve-merge.yml
+003108ea0f5c12e1db591cd4613304d8 dependabot-approve-merge.yml
 7bcfba381bfb7c28d9ef6a7d55ac937b lint-eslint.yml
 80a58e5584612def0e751fcfb7669814 lint-info-xml.yml
 a674b6e725bcbc1064f7b68c678a2df6 lint-php-cs.yml
@@ -19,6 +19,6 @@ d17de282ccd37f12a5fd78d68a74df96 phpunit-sqlite.yml
 9fe5efdf1113d7fe92ba1f54f1111c4f psalm.yml
 7db5b820f3750eebe988005a0bb2febd reuse.yml
 9dc6b717be0006fc7974a50351686fd7 sync-workflow-templates.yml
-78bd5cbcc4b48cb9b0d1b0fbbb4403d7 update-nextcloud-ocp-approve-merge.yml
+a3440826636c0fd7c2d20b1de50363da update-nextcloud-ocp-approve-merge.yml
 94d83c701a5583dc4b36a5f471bb9e41 update-nextcloud-ocp.yml
 92a9def3f7980550ca63038403f43182 npm-build.yml

--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -59,7 +59,7 @@ jobs:
 
       # Enable GitHub auto merge
       - name: Auto merge
-        uses: alexwilson/enable-github-automerge-action@56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff # 2.0.0
+        uses: alexwilson/enable-github-automerge-action@2c32e18a76e0726ffe7a573bfff2d42a20885126 # 3.0.0
         if: startsWith(steps.branchname.outputs.branch, 'dependabot/') && (github.event.action == 'opened' || github.event.action == 'reopened') && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-nextcloud-ocp-approve-merge.yml
+++ b/.github/workflows/update-nextcloud-ocp-approve-merge.yml
@@ -53,7 +53,7 @@ jobs:
 
       # Enable GitHub auto merge
       - name: Auto merge
-        uses: alexwilson/enable-github-automerge-action@56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff # 2.0.0
+        uses: alexwilson/enable-github-automerge-action@2c32e18a76e0726ffe7a573bfff2d42a20885126 # 3.0.0
         if: startsWith(steps.branchname.outputs.branch, 'automated/noid/') && endsWith(steps.branchname.outputs.branch, 'update-nextcloud-ocp')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [dependabot-approve-merge.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/dependabot-approve-merge.yml)
- 🆙 Updated [update-nextcloud-ocp-approve-merge.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/update-nextcloud-ocp-approve-merge.yml)