### PR TITLE
Feat/add retention api events

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace OCA\Files_Retention\AppInfo;
 
+use OCA\Files_Retention\Event\AddRetentionRuleEvent;
+use OCA\Files_Retention\Event\DeleteRetentionRuleEvent;
 use OCA\Files_Retention\EventListener;
 use OCA\Files_Retention\Notification\Notifier;
 use OCP\AppFramework\App;
@@ -33,6 +35,8 @@ class Application extends App implements IBootstrap {
 		});
 
 		$context->registerEventListener(ManagerEvent::EVENT_DELETE, EventListener::class);
+		$context->registerEventListener(AddRetentionRuleEvent::class, EventListener::class);
+		$context->registerEventListener(DeleteRetentionRuleEvent::class, EventListener::class);
 
 		$context->registerNotifierService(Notifier::class);
 	}

--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -9,17 +9,14 @@ declare(strict_types=1);
 
 namespace OCA\Files_Retention\Controller;
 
-use OCA\Files_Retention\BackgroundJob\RetentionJob;
 use OCA\Files_Retention\Constants;
+use OCA\Files_Retention\Exception\AddRuleException;
 use OCA\Files_Retention\ResponseDefinitions;
+use OCA\Files_Retention\Service\RetentionService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
-use OCP\BackgroundJob\IJobList;
-use OCP\IDBConnection;
 use OCP\IRequest;
-use OCP\SystemTag\ISystemTagManager;
-use OCP\SystemTag\TagNotFoundException;
 
 /**
  * @psalm-import-type Files_RetentionRule from ResponseDefinitions
@@ -28,9 +25,7 @@ class APIController extends OCSController {
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		private readonly IDBConnection $db,
-		private readonly ISystemTagManager $tagManager,
-		private readonly IJobList $jobList,
+		private readonly RetentionService $retentionService,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -43,44 +38,9 @@ class APIController extends OCSController {
 	 * 200: List retention rules
 	 */
 	public function getRetentions(): DataResponse {
-		$qb = $this->db->getQueryBuilder();
+		$retentions = $this->retentionService->getRetentions();
 
-		$qb->select('*')
-			->from('retention')
-			->orderBy('id');
-
-		$cursor = $qb->executeQuery();
-
-		$result = $tagIds = [];
-		while ($data = $cursor->fetch()) {
-			$tagIds[] = (string)$data['tag_id'];
-			$hasJob = $this->jobList->has(RetentionJob::class, ['tag' => (int)$data['tag_id']]);
-			if (!$hasJob) {
-				$this->jobList->add(RetentionJob::class, ['tag' => (int)$data['tag_id']]);
-			}
-
-			$result[] = [
-				'id' => (int)$data['id'],
-				'tagid' => (int)$data['tag_id'],
-				'timeunit' => (int)$data['time_unit'],
-				'timeamount' => (int)$data['time_amount'],
-				'timeafter' => (int)$data['time_after'],
-				'hasJob' => true,
-			];
-		}
-		$cursor->closeCursor();
-
-		try {
-			$this->tagManager->getTagsByIds($tagIds);
-		} catch (TagNotFoundException $e) {
-			$missingTags = array_map('intval', $e->getMissingTags());
-
-			$result = array_values(array_filter($result, static function (array $rule) use ($missingTags): bool {
-				return !in_array($rule['tagid'], $missingTags, true);
-			}));
-		}
-
-		return new DataResponse($result);
+		return new DataResponse($retentions);
 	}
 
 	/**
@@ -99,47 +59,10 @@ class APIController extends OCSController {
 	 */
 	public function addRetention(int $tagid, int $timeunit, int $timeamount, int $timeafter = Constants::MODE_CTIME): DataResponse {
 		try {
-			$this->tagManager->getTagsByIds((string)$tagid);
-		} catch (\InvalidArgumentException) {
-			return new DataResponse(['error' => 'tagid'], Http::STATUS_BAD_REQUEST);
+			$id = $this->retentionService->addRetention($tagid, $timeunit, $timeamount, $timeafter);
+		} catch (AddRuleException $e) {
+			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}
-
-		if ($timeunit < 0 || $timeunit > 3) {
-			return new DataResponse(['error' => 'timeunit'], Http::STATUS_BAD_REQUEST);
-		}
-		if ($timeamount < 1 || $timeamount > 32_000) {
-			return new DataResponse(['error' => 'timeamount'], Http::STATUS_BAD_REQUEST);
-		}
-		if ($timeafter < 0 || $timeafter > 1) {
-			return new DataResponse(['error' => 'timeafter'], Http::STATUS_BAD_REQUEST);
-		}
-
-		// Fetch tag_id
-		$qb = $this->db->getQueryBuilder();
-		$qb->select('tag_id')
-			->from('retention')
-			->where($qb->expr()->eq('tag_id', $qb->createNamedParameter($tagid)))
-			->setMaxResults(1);
-		$cursor = $qb->executeQuery();
-		$data = $cursor->fetch();
-		$cursor->closeCursor();
-
-		if ($data !== false) {
-			return new DataResponse(['error' => 'tagid'], Http::STATUS_BAD_REQUEST);
-		}
-
-		$qb = $this->db->getQueryBuilder();
-		$qb->insert('retention')
-			->setValue('tag_id', $qb->createNamedParameter($tagid))
-			->setValue('time_unit', $qb->createNamedParameter($timeunit))
-			->setValue('time_amount', $qb->createNamedParameter($timeamount))
-			->setValue('time_after', $qb->createNamedParameter($timeafter));
-
-		$qb->executeStatement();
-		$id = $qb->getLastInsertId();
-
-		//Insert cronjob
-		$this->jobList->add(RetentionJob::class, ['tag' => $tagid]);
 
 		return new DataResponse([
 			'id' => $id,
@@ -161,29 +84,8 @@ class APIController extends OCSController {
 	 * 404: Retention rule not found
 	 */
 	public function deleteRetention(int $id): DataResponse {
-		// Fetch tag_id
-		$qb = $this->db->getQueryBuilder();
-		$qb->select('tag_id')
-			->from('retention')
-			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
-			->setMaxResults(1);
-		$cursor = $qb->executeQuery();
-		$data = $cursor->fetch();
-		$cursor->closeCursor();
+		$removed = $this->retentionService->deleteRetention($id);
 
-		if ($data === false) {
-			return new DataResponse([], Http::STATUS_NOT_FOUND);
-		}
-
-		// Remove from retention db
-		$qb = $this->db->getQueryBuilder();
-		$qb->delete('retention')
-			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
-		$qb->executeStatement();
-
-		// Remove cronjob
-		$this->jobList->remove(RetentionJob::class, ['tag' => (int)$data['tag_id']]);
-
-		return new DataResponse([], Http::STATUS_NO_CONTENT);
+		return new DataResponse([], $removed === false ? Http::STATUS_NOT_FOUND : Http::STATUS_NO_CONTENT);
 	}
 }

--- a/lib/Event/AddRetentionRuleEvent.php
+++ b/lib/Event/AddRetentionRuleEvent.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Retention\Event;
+
+use OCA\Files_Retention\Constants;
+use OCP\EventDispatcher\Event;
+
+/**
+ * Event that can be emitted by apps to register a new retention rule.
+ */
+class AddRetentionRuleEvent extends Event {
+
+	private ?int $id = null;
+
+	/**
+	 * @param int $tagid Tag the retention is based on
+	 * @param int $timeunit Time unit of the retention (0 = days, 1 = weeks, 2 = months, 3 = years)
+	 * @psalm-param Constants::UNIT_* $timeunit
+	 * @param positive-int $timeamount Amount of time units that have to be passed
+	 * @param int $timeafter Whether retention time is based creation time (0) or modification time (1)
+	 * @psalm-param Constants::MODE_* $timeafter
+	 */
+	public function __construct(
+		public readonly int $tagId,
+		public readonly int $timeUnit,
+		public readonly int $timeAmount,
+		public readonly int $timeAfter,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * @return ?int the ID of the retention rule if created, null otherwise
+	 */
+	public function getId(): ?int {
+		return $this->id;
+	}
+
+	public function setId(int $id): void {
+		$this->id = $id;
+	}
+
+}

--- a/lib/Event/DeleteRetentionRuleEvent.php
+++ b/lib/Event/DeleteRetentionRuleEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Retention\Event;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Event that can be emitted by apps to delete a new retention rule.
+ */
+class DeleteRetentionRuleEvent extends Event {
+
+	private bool $success = false;
+
+	public function __construct(
+		public readonly int $id,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * @return bool false if the deletion was not successful
+	 */
+	public function isSuccessful(): bool {
+		return $this->success;
+	}
+
+	public function setSuccess(bool $success): void {
+		$this->success = $success;
+	}
+}

--- a/lib/EventListener.php
+++ b/lib/EventListener.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 
 namespace OCA\Files_Retention;
 
+use OCA\Files_Retention\Event\AddRetentionRuleEvent;
+use OCA\Files_Retention\Event\DeleteRetentionRuleEvent;
+use OCA\Files_Retention\Service\RetentionService;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -23,16 +26,25 @@ class EventListener implements IEventListener {
 	public function __construct(
 		private readonly IDBConnection $db,
 		private readonly LoggerInterface $logger,
+		private readonly RetentionService $retentionService,
 	) {
 	}
 
 	#[\Override]
 	public function handle(Event $event): void {
-		if (!$event instanceof ManagerEvent) {
-			return;
+		if ($event instanceof ManagerEvent) {
+			$this->tagDeleted($event->getTag());
 		}
 
-		$this->tagDeleted($event->getTag());
+		if ($event instanceof AddRetentionRuleEvent) {
+			$id = $this->retentionService->addRetention($event->tagId, $event->timeUnit, $event->timeAmount, $event->timeAfter);
+			$event->setId($id);
+		}
+
+		if ($event instanceof DeleteRetentionRuleEvent) {
+			$this->retentionService->deleteRetention($event->id);
+			$event->setSuccess(true);
+		}
 	}
 
 	protected function tagDeleted(ISystemTag $tag): void {

--- a/lib/Exception/AddRuleException.php
+++ b/lib/Exception/AddRuleException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Retention\Exception;
+
+class AddRuleException extends \Exception {
+}

--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Retention\Service;
+
+use OCA\Files_Retention\BackgroundJob\RetentionJob;
+use OCA\Files_Retention\Exception\AddRuleException;
+use OCP\BackgroundJob\IJobList;
+use OCP\IDBConnection;
+use OCP\SystemTag\ISystemTagManager;
+use OCP\SystemTag\TagNotFoundException;
+
+class RetentionService {
+
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly ISystemTagManager $tagManager,
+		private readonly IJobList $jobList,
+	) {
+	}
+
+	/**
+	 * @return int ID of the inserted retention rule
+	 * @throws AddRuleException when a rule has an invalid value
+	 */
+	public function addRetention(int $tagId, int $timeUnit, int $timeAmount, int $timeAfter): int {
+		try {
+			$this->tagManager->getTagsByIds((string)$tagId);
+		} catch (\InvalidArgumentException) {
+			throw new AddRuleException('tagid');
+		}
+
+		if ($timeUnit < 0 || $timeUnit > 3) {
+			throw new AddRuleException('timeunit');
+		}
+		if ($timeAmount < 1 || $timeAmount > 32_000) {
+			throw new AddRuleException('timeamount');
+		}
+		if ($timeAfter < 0 || $timeAfter > 1) {
+			throw new AddRuleException('timeafter');
+		}
+
+		// Fetch tag_id
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('tag_id')
+			->from('retention')
+			->where($qb->expr()->eq('tag_id', $qb->createNamedParameter($tagId)))
+			->setMaxResults(1);
+		$cursor = $qb->executeQuery();
+		$data = $cursor->fetch();
+		$cursor->closeCursor();
+
+		if ($data !== false) {
+			throw new AddRuleException('tagid');
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->insert('retention')
+			->setValue('tag_id', $qb->createNamedParameter($tagId))
+			->setValue('time_unit', $qb->createNamedParameter($timeUnit))
+			->setValue('time_amount', $qb->createNamedParameter($timeAmount))
+			->setValue('time_after', $qb->createNamedParameter($timeAfter));
+
+		$qb->executeStatement();
+		$id = $qb->getLastInsertId();
+
+		//Insert cronjob
+		$this->jobList->add(RetentionJob::class, ['tag' => $tagId]);
+
+		return $id;
+	}
+
+	/**
+	 * @param int $id ID of the retention rule to remove
+	 * @return bool true if the retention was removed, false otherwise
+	 */
+	public function deleteRetention(int $id): bool {
+		// Fetch tag_id
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('tag_id')
+			->from('retention')
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
+			->setMaxResults(1);
+		$cursor = $qb->executeQuery();
+		$data = $cursor->fetch();
+		$cursor->closeCursor();
+
+		if ($data === false) {
+			return false;
+		}
+
+		// Remove from retention db
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete('retention')
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
+		$qb->executeStatement();
+
+		// Remove cronjob
+		$this->jobList->remove(RetentionJob::class, ['tag' => (int)$data['tag_id']]);
+
+		return true;
+	}
+
+	/**
+	 * @return list<array{id: int, tagid: int, timeunit: int, timeamount: int, timeafter: int, hasJob: true}>
+	 */
+	public function getRetentions(): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			->from('retention')
+			->orderBy('id');
+
+		$cursor = $qb->executeQuery();
+
+		$result = $tagIds = [];
+		while ($data = $cursor->fetch()) {
+			$tagIds[] = (string)$data['tag_id'];
+			$hasJob = $this->jobList->has(RetentionJob::class, ['tag' => (int)$data['tag_id']]);
+			if (!$hasJob) {
+				$this->jobList->add(RetentionJob::class, ['tag' => (int)$data['tag_id']]);
+			}
+
+			$result[] = [
+				'id' => (int)$data['id'],
+				'tagid' => (int)$data['tag_id'],
+				'timeunit' => (int)$data['time_unit'],
+				'timeamount' => (int)$data['time_amount'],
+				'timeafter' => (int)$data['time_after'],
+				'hasJob' => true,
+			];
+		}
+		$cursor->closeCursor();
+
+		try {
+			$this->tagManager->getTagsByIds($tagIds);
+		} catch (TagNotFoundException $e) {
+			$missingTags = array_map('intval', $e->getMissingTags());
+
+			$result = array_values(array_filter($result, static function (array $rule) use ($missingTags): bool {
+				return !in_array($rule['tagid'], $missingTags, true);
+			}));
+		}
+
+		return $result;
+	}
+
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,7 +4,7 @@
     findUnusedBaselineEntry="true"
     findUnusedCode="false"
     resolveFromConfigFile="true"
-    phpVersion="8.2"
+    phpVersion="8.3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/tests/lib/Contoller/APIControllerTest.php
+++ b/tests/lib/Contoller/APIControllerTest.php
@@ -11,6 +11,7 @@ namespace OCA\Files_Retention\Tests\Controller;
 use OCA\Files_Retention\BackgroundJob\RetentionJob;
 use OCA\Files_Retention\Constants;
 use OCA\Files_Retention\Controller\APIController;
+use OCA\Files_Retention\Service\RetentionService;
 use OCP\AppFramework\Http;
 use OCP\BackgroundJob\IJobList;
 use OCP\IDBConnection;
@@ -38,13 +39,12 @@ class APIControllerTest extends \Test\TestCase {
 		$this->db = \OCP\Server::get(IDBConnection::class);
 		$this->tagManager = $this->createMock(ISystemTagManager::class);
 		$this->jobList = $this->createMock(IJobList::class);
+		$retentionService = new RetentionService($this->db, $this->tagManager, $this->jobList);
 
 		$this->api = new APIController(
 			$this->appName,
 			$this->request,
-			$this->db,
-			$this->tagManager,
-			$this->jobList
+			$retentionService,
 		);
 	}
 

--- a/tests/lib/EventListenerTest.php
+++ b/tests/lib/EventListenerTest.php
@@ -26,7 +26,10 @@ declare(strict_types=1);
 namespace OCA\Files_Retention\Tests;
 
 use OCA\Files_Retention\Constants;
+use OCA\Files_Retention\Event\AddRetentionRuleEvent;
+use OCA\Files_Retention\Event\DeleteRetentionRuleEvent;
 use OCA\Files_Retention\EventListener;
+use OCA\Files_Retention\Service\RetentionService;
 use OCP\IDBConnection;
 use OCP\SystemTag\ISystemTagManager;
 use PHPUnit\Framework\Attributes\Group;
@@ -38,6 +41,7 @@ class EventListenerTest extends \Test\TestCase {
 	private IDBConnection $db;
 	private LoggerInterface&MockObject $logger;
 	private ISystemTagManager $tagManager;
+	private RetentionService $retentionService;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -45,6 +49,7 @@ class EventListenerTest extends \Test\TestCase {
 		$this->db = \OCP\Server::get(IDBConnection::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->tagManager = \OCP\Server::get(ISystemTagManager::class);
+		$this->retentionService = \OCP\Server::get(RetentionService::class);
 	}
 
 	protected function tearDown(): void {
@@ -54,13 +59,56 @@ class EventListenerTest extends \Test\TestCase {
 		$qb->executeStatement();
 	}
 
-	private function addTag(int $tagId, int $timeunit, int $timeamount): void {
+	private function addTag(int $tagId, int $timeunit, int $timeamount): int {
 		$qb = $this->db->getQueryBuilder();
 		$qb->insert('retention')
 			->setValue('tag_id', $qb->createNamedParameter($tagId))
 			->setValue('time_unit', $qb->createNamedParameter($timeunit))
 			->setValue('time_amount', $qb->createNamedParameter($timeamount));
 		$qb->executeStatement();
+
+		return $qb->getLastInsertId();
+	}
+
+	public function testAddRetentionRule(): void {
+		$tag = $this->tagManager->createTag(self::getUniqueID('foo'), true, true);
+		$event = new AddRetentionRuleEvent((int)$tag->getId(), 0, 1, 0);
+
+		$eventListener = new EventListener($this->db, $this->logger, $this->retentionService);
+		$eventListener->handle($event);
+
+		$this->assertNotNull($event->getId());
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from('retention')
+			->where($qb->expr()->eq('tag_id', $qb->createNamedParameter($tag->getId())));
+		$cursor = $qb->executeQuery();
+		$data = $cursor->fetchAll();
+		$cursor->closeCursor();
+
+		$this->assertCount(1, $data);
+	}
+
+	public function testRemoveRetentionRule(): void {
+		$tag = $this->tagManager->createTag(self::getUniqueID('foo'), true, true);
+		$this->tagManager->deleteTags($tag->getId());
+		$ruleId = $this->addTag((int)$tag->getId(), 1, Constants::UNIT_DAY);
+		$event = new DeleteRetentionRuleEvent($ruleId);
+
+		$eventListener = new EventListener($this->db, $this->logger, $this->retentionService);
+		$eventListener->handle($event);
+
+		$this->assertEquals(true, $event->isSuccessful());
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from('retention');
+		$cursor = $qb->executeQuery();
+		$data = $cursor->fetchAll();
+		$cursor->closeCursor();
+
+		$this->assertCount(0, $data);
 	}
 
 	public function testTagDeleted(): void {
@@ -68,7 +116,7 @@ class EventListenerTest extends \Test\TestCase {
 		$this->tagManager->deleteTags($tag->getId());
 		$this->addTag((int)$tag->getId(), 1, Constants::UNIT_DAY);
 
-		$eventListener = new EventListener($this->db, $this->logger);
+		$eventListener = new EventListener($this->db, $this->logger, $this->retentionService);
 		self::invokePrivate($eventListener, 'tagDeleted', [$tag]);
 
 		$qb = $this->db->getQueryBuilder();


### PR DESCRIPTION
This PR:
  - Adds `AddRetentionRuleEvent`, `DeleteRetentionRuleEvent` to allow adding a retention rule for a tag and deleting it by its ID
  - Modified existing listener to add behaviour for the events above
  - Extracted code to`RetentionService` with logic from `ApiController`
  - Adds `AddRuleException` thrown by `RetentionService`
  - Updates tests to reflect the new changes and cover the new cases