### PR TITLE
[stable33] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "740d19e08b1ebe5a27c439b3954ecc2634fe12f5"
+                "reference": "e327ea0683dc8ac6099dc4311537ecac9e6123e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/740d19e08b1ebe5a27c439b3954ecc2634fe12f5",
-                "reference": "740d19e08b1ebe5a27c439b3954ecc2634fe12f5",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e327ea0683dc8ac6099dc4311537ecac9e6123e8",
+                "reference": "e327ea0683dc8ac6099dc4311537ecac9e6123e8",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-06-12T14:49:06+00:00"
+            "time": "2026-06-18T02:35:59+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency