### PR TITLE
Use SPDX license identifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description>An app for Nextcloud to control automatic deletion of files after a given time.
 Optionally the users can be informed the day before.</description>
 	<version>6.0.0-dev.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 	<author>Roeland Jago Douma</author>
 	<namespace>Files_Retention</namespace>
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	},
 	"name": "nextcloud/files_retention",
 	"description": "files_retention",
-	"license": "AGPL",
+	"license": "AGPL-3.0-or-later",
 	"config": {
 		"optimize-autoloader": true,
 		"classmap-authoritative": true,

--- a/openapi.json
+++ b/openapi.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "This application allows for automatic deletion of files after a given time.",
         "license": {
-            "name": "agpl"
+            "name": "AGPL-3.0-or-later"
         }
     },
     "components": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "files_retention",
   "version": "6.0.0-dev.0",
   "author": "Joas Schilling <coding@schilljs.com>",
-  "license": "agpl",
+  "license": "AGPL-3.0-or-later",
   "private": true,
   "scripts": {
     "build": "NODE_ENV=production webpack --progress",


### PR DESCRIPTION
unifying the license string, already used in package.json and supported in info.xml since 31, so no issue given min-version is set to 35 at the moment.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
